### PR TITLE
Multiplication performance

### DIFF
--- a/lib/gurobi.rb
+++ b/lib/gurobi.rb
@@ -1,6 +1,5 @@
 require "gurobi/version"
 require 'gurobi/gurobi'
-require 'gurobi/core_ext'
 
 module Gurobi
   # Your code goes here...


### PR DESCRIPTION
Just a suggestion that you might want to consider removing `multiply_with_gurobi`. It forces all multiplications to be done through this function which can significantly impact the performance of code which has nothing to do with Gurobi. Alternatively, perhaps there could be a method that explicitly activates this behaviour.
